### PR TITLE
Landscaper: "update-canjs-3.11" services

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
     "arcgis-js-api": "github:Esri/arcgis-js-api#4master",
     "can-admin": "github:roemhildtg/can-admin",
     "can-assign": "^1.0.0",
-    "can-component": "^3.3.4",
-    "can-define": "^1.4.4",
-    "can-observation": "^3.3.5",
-    "can-reflect": "^1.4.5",
-    "can-route": "^3.2.3",
-    "can-stache": "^3.6.2",
+    "can-component": "3.3.4",
+    "can-define": "1.5.1",
+    "can-observation": "3.3.5",
+    "can-reflect": "1.4.5",
+    "can-route": "3.2.3",
+    "can-stache": "3.9.0",
     "dgrid": "^1.2.1",
     "esri-loader": "^1.0.0",
     "esri-promise": "^0.3.0",
@@ -29,10 +29,10 @@
   "devDependencies": {
     "babel-eslint": "^7.2.3",
     "eslint": "^4.6.1",
-    "steal-css": "^1.3.1",
+    "steal-css": "^1.2.4",
     "steal-less": "^1.2.0",
-    "steal-stache": "^3.1.1",
-    "steal-tools": "^1.8.4"
+    "steal-stache": "^3.1.0",
+    "steal-tools": "^1.3.6"
   },
   "steal": {
     "plugins": [


### PR DESCRIPTION
This pull request was created with [Landscaper](https://github.com/bitovi/landscaper).
The following code mods were used to create this PR:

1. **https://gist.githubusercontent.com/roemhildtg/e92d71f26006deb871f908a36e93647c/raw/f06d1833dcd7bade5773a740c8ee3f34278c6ab7/canjs-canjs-deps.js**

Please review this PR carefully as Landscaper does not guarantee any code mod's quality.